### PR TITLE
fix(jobs): specify job_arg_schema

### DIFF
--- a/invenio_moodle/jobs.py
+++ b/invenio_moodle/jobs.py
@@ -7,7 +7,6 @@
 
 """Jobs."""
 
-
 from invenio_jobs.jobs import JobType, PredefinedArgsSchema
 from invenio_jobs.models import Job
 from marshmallow.fields import String
@@ -17,6 +16,12 @@ from .tasks import import_records
 
 class MoodlePredefinedArgsSchema(PredefinedArgsSchema):
     """Moodle predefined args schema."""
+
+    job_arg_schema = String(
+        metadata={"type": "hidden"},
+        dump_default="MoodlePredefinedArgsSchema",
+        load_default="MoodlePredefinedArgsSchema",
+    )
 
     dry_run = String(
         metadata={


### PR DESCRIPTION
  * dry_run was not recognized as a valid arg by the MoodlePrefedfinedArgsSchema.
    this was because the job_arg_schema arg was not overridden and pointed to the
    base class schema which contains only "since" arg. updated the job_arg_schema
    with the correct schema (Moodle)